### PR TITLE
[fix]ci.ymlとsrc/app/page.tsxを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
 
       - name: Build Next.js
         working-directory: frontend
-        run: npm run build
+        run: |
+          NEXT_PUBLIC_API_URL="${{ github.event_name != 'pull_request' && secrets.PROD_API_URL || secrets.DEV_API_URL }}" \
+          NEXT_PUBLIC_ADMIN_PIN="${{ secrets.ADMIN_PIN }}" \
+          NODE_ENV="${{ github.event_name != 'pull_request' && 'production' || 'development' }}" \
+          npm run build
 
       - name: Upload build artifact
         if: github.event_name != 'pull_request'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   const [message, setMessage] = useState("Loading...");
 
   useEffect(() => {
-    fetch("http://localhost:8000/") // FastAPI の URL に合わせて変更
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/`) 
       .then((res) => res.json())
       .then((data) => setMessage(data.message))
       .catch(() => setMessage("Error fetching message from FastAPI."));


### PR DESCRIPTION
## 目的
-  開発・本番環境ごとにAPIエンドポイントを切り替えられるようにする
-  本番用の環境変数を利用してビルドできるようにする

## 実装の概要/やったこと
- ci.ymlで、ビルド時に環境変数（API URL、管理者PIN、NODE_ENV）を渡すように修正し、.envファイルに依存せずに本番ビルドが可能なようにした
- フロントエンドのAPIリクエストURLを環境変数（NEXT_PUBLIC_API_URL）から取得するように変更し、開発・本番環境の切り替えを容易にした
- 上記に伴い、開発・本番環境ごとの .env を使い分けてローカルでビルドする仕組みを導入（Mattermostで.envファイルを共有済み）

- このプルリクで何をしたのか？

## 保留/やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」でOK）
- 開発・本番環境で正しいAPI URLに自動でアクセスできるようになり、環境の切り替えがスムーズになる
- 本番環境用ビルドがCI上で安全かつ安定的に行えるようになる

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
