### PR TITLE
管理画面UIの作成と各リンク修正

### DIFF
--- a/src/app/admin-home/admin-posts/page.tsx
+++ b/src/app/admin-home/admin-posts/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import "../../../styles/common.css";
+
+export default function PostListPage() {
+  useEffect(() => {
+    document.body.classList.add("washitsu");
+    return () => {
+      document.body.classList.remove("washitsu");
+    };
+  }, []);
+
+  return (
+    <main className="relative flex h-screen w-full">
+      {/* サイドバー */}
+      <aside className="fixed top-0 left-0 h-full w-64 bg-gray-800 text-white p-4 space-y-6 z-10 flex flex-col justify-between">
+        <div>
+          <div className="text-xl font-bold mb-6">さぶちゃん管理システム</div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <Link href="/admin-home/admin-users" className="top-button text-center">ユーザー管理</Link>
+          <Link href="/admin-home/admin-posts" className="top-button text-center">投稿内容の一覧</Link>
+          <Link href="/admin-home/admin-settings" className="top-button text-center">設定変更</Link>
+        </div>
+      </aside>
+
+      {/* メインコンテンツ */}
+      <section className="ml-64 flex-grow bg-white p-10 relative overflow-hidden">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-semibold">投稿内容の一覧</h1>
+          <Link href="/" className="text-blue-600 hover:underline">ログアウト</Link>
+        </div>
+
+        <div className="bg-gray-100 p-4 rounded shadow-md mb-6">
+          <h2 className="font-bold mb-4">投稿一覧</h2>
+          <table className="w-full table-auto text-left border">
+            <thead>
+              <tr className="bg-gray-200">
+                <th className="p-2 border">投稿者</th>
+                <th className="p-2 border">内容</th>
+                <th className="p-2 border">投稿日</th>
+              </tr>
+            </thead>
+            <tbody>
+              {/* 仮データ */}
+              <tr>
+                <td className="p-2 border">田中 太郎</td>
+                <td className="p-2 border">こんにちは、これはテスト投稿です！</td>
+                <td className="p-2 border">2025/05/01</td>
+              </tr>
+              <tr>
+                <td className="p-2 border">鈴木 花子</td>
+                <td className="p-2 border">本日は晴天なり☀️</td>
+                <td className="p-2 border">2025/05/02</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* アニメーションロゴ */}
+        <img
+          src="/images/sabuchan_logo.png"
+          alt="さぶちゃん日記"
+          className="w-[400px] h-auto absolute bottom-4 right-4 rounded z-0 opacity-30"
+        />
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin-home/admin-users/page.tsx
+++ b/src/app/admin-home/admin-users/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import "../../../styles/common.css";
+
+export default function UserManagement() {
+  useEffect(() => {
+    document.body.classList.add("washitsu");
+    return () => {
+      document.body.classList.remove("washitsu");
+    };
+  }, []);
+
+  return (
+    <main className="relative flex h-screen w-full">
+      {/* サイドバー */}
+      <aside className="fixed top-0 left-0 h-full w-64 bg-gray-800 text-white p-4 space-y-6 z-10 flex flex-col justify-between">
+        <div>
+          <div className="text-xl font-bold mb-6">さぶちゃん管理システム</div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <Link href="/admin-home/admin-users" className="top-button text-center">ユーザー管理</Link>
+          <Link href="/admin-home/admin-posts" className="top-button text-center">投稿内容の一覧</Link>
+          <button className="top-button">設定変更</button>
+        </div>
+      </aside>
+
+      {/* メインコンテンツ */}
+      <section className="ml-64 flex-grow bg-white p-10 relative overflow-hidden">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-semibold">ユーザー管理</h1>
+          <Link href="/" className="text-blue-600 hover:underline">ログアウト</Link>
+        </div>
+
+        <div className="bg-gray-100 p-4 rounded shadow-md mb-6">
+          <h2 className="font-bold mb-4">ユーザー一覧</h2>
+          <table className="w-full table-auto text-left border">
+            <thead>
+              <tr className="bg-gray-200">
+                <th className="p-2 border">ユーザー名</th>
+                <th className="p-2 border">メールアドレス</th>
+                <th className="p-2 border">状態</th>
+                <th className="p-2 border">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {/* 仮のデータを表示（後でAPI連携） */}
+              <tr>
+                <td className="p-2 border">田中 太郎</td>
+                <td className="p-2 border">tanaka@example.com</td>
+                <td className="p-2 border text-green-600">アクティブ</td>
+                <td className="p-2 border space-x-2">
+                  <button className="text-blue-600 hover:underline">編集</button>
+                  <button className="text-yellow-600 hover:underline">凍結</button>
+                  <button className="text-red-600 hover:underline">削除</button>
+                </td>
+              </tr>
+              <tr>
+                <td className="p-2 border">鈴木 花子</td>
+                <td className="p-2 border">hanako@example.com</td>
+                <td className="p-2 border text-red-500">無効</td>
+                <td className="p-2 border space-x-2">
+                  <button className="text-blue-600 hover:underline">編集</button>
+                  <button className="text-green-600 hover:underline">復活</button>
+                  <button className="text-red-600 hover:underline">削除</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* アニメーションロゴ */}
+        <img
+          src="/images/sabuchan_logo.png"
+          alt="さぶちゃん日記"
+          className="w-[400px] h-auto absolute bottom-4 right-4 rounded z-0 opacity-30"
+        />
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin-home/page.tsx
+++ b/src/app/admin-home/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import "../../styles/common.css";
+
+export default function AdminDashboard() {
+  useEffect(() => {
+    document.body.classList.add("washitsu");
+    return () => {
+      document.body.classList.remove("washitsu");
+    };
+  }, []);
+
+  return (
+    <main className="relative flex h-screen w-full">
+      {/* サイドバー */}
+      <aside className="fixed top-0 left-0 h-full w-64 bg-gray-800 text-white p-4 space-y-6 z-10 flex flex-col justify-between">
+        <div>
+          <div className="text-xl font-bold mb-6">さぶちゃん管理システム</div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <Link href="/admin-home/admin-users" className="top-button text-center">ユーザー管理</Link>
+          <Link href="/admin-home/admin-posts" className="top-button text-center">投稿内容の一覧</Link>
+          <button className="top-button">設定変更</button>
+        </div>
+      </aside>
+
+      {/* メインコンテンツ */}
+      <section className="ml-64 flex-grow bg-white p-10 relative overflow-hidden">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-semibold">ダッシュボード</h1>
+          <Link href="/" className="text-blue-600 hover:underline">ログアウト</Link>
+        </div>
+
+        <p className="mb-6">こんにちは、admin@example.com さん！</p>
+
+        <div className="bg-gray-100 p-4 rounded shadow-md mb-6">
+          <h2 className="font-bold mb-2">概要</h2>
+          <ul className="list-disc list-inside space-y-1">
+            <li>登録ユーザー数：154人</li>
+            <li>無効化ユーザー数：12人</li>
+            <li>登録済メッセージ数：487件</li>
+          </ul>
+        </div>
+
+        {/* アニメーションロゴ */}
+        <img
+          src="/images/sabuchan_logo.png"
+          alt="さぶちゃん日記"
+          className="w-[400px] h-auto absolute bottom-4 right-4 rounded z-0 opacity-30"
+        />
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,22 +21,23 @@ export default function Home() {
 
   return (
     <main className="relative flex flex-col items-center justify-center min-h-screen gap-10 overflow-hidden">
-      {/* アニメーション：右上 → 左下 → ロゴ位置 → 膨らんで弾ける */}
+      {/* アニメーション：右上 → 左下で回転＆弾ける */}
       <motion.img
         src="/images/sabuchan.png"
         alt="弾けるさぶちゃん"
         className="w-[200px] h-auto absolute z-0"
-        initial={{ x: 400, y: -400, scale: 1, opacity: 1 }}
+        initial={{ x: 400, y: -400, rotate: 0, scale: 1, opacity: 1 }}
         animate={{
-          x: [400, -400, 0, 0],
-          y: [-400, 400, -100, -100],
-          scale: [1, 1, 1, 2, 0],
+          x: [400, 200, 0, -200, -400],
+          y: [-400, -200, 0, 200, 400],
+          rotate: [0, 90, 180, 270, 360],
+          scale: [1, 1, 1, 1.3, 0],
           opacity: [1, 1, 1, 1, 0],
         }}
         transition={{
-          duration: 6,
+          duration: 3,
           ease: "easeInOut",
-          times: [0, 0.4, 0.7, 0.85, 1],
+          times: [0, 0.25, 0.5, 0.75, 1],
         }}
       />
 


### PR DESCRIPTION
## 目的  
管理画面の UI をシンプルにし、**ユーザー管理・投稿一覧などの画面遷移を明確にするため**

## 実装の概要 / やったこと  
- サイドバーの不要なナビゲーション（`<nav>`）を削除  
- 「さぶちゃん管理システム」テキストを **クリックで `/admin-home` に遷移** するように変更  
- 「ユーザー管理」ボタンを **`/admin-home/admin-users` にリンク化**  
- 「投稿内容の一覧」ボタンを **`/admin-home/admin-posts` にリンク化**  
- 「ログアウト」ボタンを **クリックでトップ画面（`/`）へ遷移** するよう変更  

## 保留 / やらないこと  
- **API との接続（ユーザー一覧・投稿一覧の取得）は未対応**  
  → 今後の実装で対応予定（別 PR にて）  

## できるようになること（ユーザ目線）  
- 各種ボタンから **適切な画面へ遷移できるようになる**  

## できなくなること（ユーザ目線）  
- サイドバーにあった **旧ナビゲーションメニューからのページ遷移**  

## 動作確認  
- ローカル環境で **各リンクボタンの動作を確認** し、想定通りのページへ遷移することを確認  
- **UI が崩れないことを目視で確認**  

## その他  

**close #（該当 issue があれば記載）**  
**@（レビュー担当者を記載）**  
