### PR TITLE
Admin UI update2

### DIFF
--- a/src/app/admin-home/admin-posts/page.tsx
+++ b/src/app/admin-home/admin-posts/page.tsx
@@ -1,16 +1,36 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import "../../../styles/common.css";
 
+interface Message {
+  id: number;
+  user: { user_name: string } | null;
+  content: string;
+  created_at: string;
+}
+
 export default function PostListPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+
   useEffect(() => {
     document.body.classList.add("washitsu");
+    fetchMessages();
     return () => {
       document.body.classList.remove("washitsu");
     };
   }, []);
+
+  const fetchMessages = async () => {
+    try {
+      const res = await fetch("http://localhost:8000/messages");
+      const data = await res.json();
+      setMessages(data);
+    } catch (error) {
+      console.error("投稿の取得に失敗しました", error);
+    }
+  };
 
   return (
     <main className="relative flex h-screen w-full">
@@ -44,17 +64,21 @@ export default function PostListPage() {
               </tr>
             </thead>
             <tbody>
-              {/* 仮データ */}
-              <tr>
-                <td className="p-2 border">田中 太郎</td>
-                <td className="p-2 border">こんにちは、これはテスト投稿です！</td>
-                <td className="p-2 border">2025/05/01</td>
-              </tr>
-              <tr>
-                <td className="p-2 border">鈴木 花子</td>
-                <td className="p-2 border">本日は晴天なり☀️</td>
-                <td className="p-2 border">2025/05/02</td>
-              </tr>
+              {messages.length > 0 ? (
+                messages.map((msg) => (
+                  <tr key={msg.id}>
+                    <td className="p-2 border">{msg.user?.user_name || "匿名"}</td>
+                    <td className="p-2 border">{msg.content}</td>
+                    <td className="p-2 border">{new Date(msg.created_at).toLocaleDateString()}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={3} className="p-2 border text-center text-gray-500">
+                    投稿がまだありません。
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>

--- a/src/app/admin-home/admin-settings/page.tsx
+++ b/src/app/admin-home/admin-settings/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import "../../../styles/common.css";
+
+export default function AdminSettingsPage() {
+  const [message, setMessage] = useState("");
+  const [newMessage, setNewMessage] = useState("");
+  const [status, setStatus] = useState("");
+
+  useEffect(() => {
+    document.body.classList.add("washitsu");
+    fetchCurrentMessage();
+    return () => {
+      document.body.classList.remove("washitsu");
+    };
+  }, []);
+
+  const fetchCurrentMessage = async () => {
+    try {
+      const res = await fetch("http://localhost:8000/settings");
+      const data = await res.json();
+      setMessage(data.support_message);
+      setNewMessage(data.support_message);
+    } catch (err) {
+      console.error("現在の設定取得に失敗しました", err);
+    }
+  };
+
+  const updateMessage = async () => {
+    try {
+      const res = await fetch("http://localhost:8000/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ new_message: newMessage }),
+      });
+      if (res.ok) {
+        setStatus("✅ 更新が完了しました。");
+        fetchCurrentMessage();
+      } else {
+        const error = await res.json();
+        setStatus(`❌ エラー: ${error.detail || "更新に失敗しました。"}`);
+      }
+    } catch (err) {
+      console.error("更新エラー", err);
+      setStatus("❌ 通信エラーが発生しました。");
+    }
+  };
+
+  return (
+    <main className="relative flex h-screen w-full">
+      {/* サイドバー */}
+      <aside className="fixed top-0 left-0 h-full w-64 bg-gray-800 text-white p-4 space-y-6 z-10 flex flex-col justify-between">
+        <div>
+          <div className="text-xl font-bold mb-6">さぶちゃん管理システム</div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <Link href="/admin-home/admin-users" className="top-button text-center">ユーザー管理</Link>
+          <Link href="/admin-home/admin-posts" className="top-button text-center">投稿内容の一覧</Link>
+          <Link href="/admin-home/admin-settings" className="top-button text-center">設定変更</Link>
+        </div>
+      </aside>
+
+      {/* メインコンテンツ */}
+      <section className="ml-64 flex-grow bg-white p-10 relative overflow-hidden">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-semibold">設定変更</h1>
+          <Link href="/" className="text-blue-600 hover:underline">ログアウト</Link>
+        </div>
+
+        <div className="bg-gray-100 p-4 rounded shadow-md mb-6 space-y-4">
+          <h2 className="font-bold mb-2">現在のサポートメッセージ</h2>
+          <p className="bg-white p-2 border rounded">{message || "（未設定）"}</p>
+
+          <h3 className="font-bold mt-6">新しいメッセージ</h3>
+          <textarea
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            className="w-full p-2 border rounded h-32"
+            placeholder="新しいサポートメッセージを入力してください"
+          />
+
+          <button onClick={updateMessage} className="button-submit">
+            更新する
+          </button>
+
+          {status && <p className="text-sm mt-2">{status}</p>}
+        </div>
+
+        <img
+          src="/images/sabuchan_logo.png"
+          alt="さぶちゃん日記"
+          className="w-[400px] h-auto absolute bottom-4 right-4 rounded z-0 opacity-30"
+        />
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin-home/page.tsx
+++ b/src/app/admin-home/page.tsx
@@ -1,16 +1,68 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import "../../styles/common.css";
 
 export default function AdminDashboard() {
+  const [adminEmail, setAdminEmail] = useState("");
+  const [userCount, setUserCount] = useState(0);
+  const [inactiveCount, setInactiveCount] = useState(0);
+  const [messageCount, setMessageCount] = useState(0);
+  const router = useRouter();
+
   useEffect(() => {
     document.body.classList.add("washitsu");
+    fetchDashboardData();
+
     return () => {
       document.body.classList.remove("washitsu");
     };
   }, []);
+
+  const fetchDashboardData = async () => {
+    try {
+      const token = localStorage.getItem("token");
+
+      // トークン未設定時のリダイレクト（コメントアウト中）
+      // if (!token) {
+      //   router.push("/login");
+      //   return;
+      // }
+
+      const headers = {
+        Authorization: `Bearer ${token}`,
+      };
+
+      const [adminRes, usersRes, messagesRes] = await Promise.all([
+        fetch("http://localhost:8000/admin_info", { headers }),
+        fetch("http://localhost:8000/users", { headers }),
+        fetch("http://localhost:8000/messages", { headers }),
+      ]);
+
+      if (adminRes.ok && usersRes.ok && messagesRes.ok) {
+        const admin = await adminRes.json();
+        const users = await usersRes.json();
+        const messages = await messagesRes.json();
+
+        setAdminEmail(admin.email);
+        setUserCount(users.length);
+        setInactiveCount(users.filter((u: any) => !u.is_active).length);
+        setMessageCount(messages.length);
+      } else {
+        alert("情報の取得に失敗しました。再ログインしてください。");
+
+        // 認証エラー時のリダイレクト（コメントアウト中）
+        // router.push("/login");
+      }
+    } catch (error) {
+      alert("通信エラーが発生しました");
+
+      // 通信エラー時のリダイレクト（コメントアウト中）
+      // router.push("/login");
+    }
+  };
 
   return (
     <main className="relative flex h-screen w-full">
@@ -33,14 +85,14 @@ export default function AdminDashboard() {
           <Link href="/" className="text-blue-600 hover:underline">ログアウト</Link>
         </div>
 
-        <p className="mb-6">こんにちは、admin@example.com さん！</p>
+        <p className="mb-6">こんにちは、{adminEmail} さん！</p>
 
         <div className="bg-gray-100 p-4 rounded shadow-md mb-6">
           <h2 className="font-bold mb-2">概要</h2>
           <ul className="list-disc list-inside space-y-1">
-            <li>登録ユーザー数：154人</li>
-            <li>無効化ユーザー数：12人</li>
-            <li>登録済メッセージ数：487件</li>
+            <li>登録ユーザー数：{userCount}人</li>
+            <li>無効化ユーザー数：{inactiveCount}人</li>
+            <li>登録済メッセージ数：{messageCount}件</li>
           </ul>
         </div>
 

--- a/src/app/admin-home/page.tsx
+++ b/src/app/admin-home/page.tsx
@@ -74,7 +74,7 @@ export default function AdminDashboard() {
         <div className="flex flex-col gap-4">
           <Link href="/admin-home/admin-users" className="top-button text-center">ユーザー管理</Link>
           <Link href="/admin-home/admin-posts" className="top-button text-center">投稿内容の一覧</Link>
-          <button className="top-button">設定変更</button>
+          <Link href="/admin-home/admin-settings" className="top-button text-center">設定変更</Link>
         </div>
       </aside>
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -33,7 +33,7 @@ export default function Login() {
 
       if (res.ok) {
         const data = await res.json();
-        console.log("ログイン成功:", data);
+        console.log("一般ユーザーログイン成功:", data);
         router.push("/home");
       } else {
         const error = await res.json();
@@ -49,11 +49,26 @@ export default function Login() {
     setShowPinDialog(true);
   };
 
-  const handleConfirmPin = () => {
-    if (pinCode === process.env.NEXT_PUBLIC_ADMIN_PIN) {
-      router.push("/admin-home");
-    } else {
-      alert("PINコードが間違っています！");
+  const handleAdminLogin = async () => {
+    try {
+      const res = await fetch("http://localhost:8000/admin/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email, password, pin_code: pinCode }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        console.log("管理者ログイン成功:", data);
+        router.push("/admin-home");
+      } else {
+        const error = await res.json();
+        alert(error.detail || "管理者ログインに失敗しました");
+      }
+    } catch {
+      alert("通信エラーが発生しました");
     }
   };
 
@@ -114,7 +129,7 @@ export default function Login() {
                 キャンセル
               </button>
               <button
-                onClick={handleConfirmPin}
+                onClick={handleAdminLogin}
                 className="button-submit"
               >
                 確認


### PR DESCRIPTION
- **目的**  
  管理画面（ダッシュボード、ユーザー一覧、投稿一覧、設定）のUIを整備し、管理機能を視覚的・操作的に使いやすくするため。

- **実装の概要/やったこと**  
  - サイドバー内の各リンク（ユーザー管理、投稿一覧、設定変更）を `<Link>` 化してルーティング対応  
  - サイドバー上部の「さぶちゃん管理システム」を `/admin-home` にリンク化  
  - ダッシュボードに管理者のメールアドレス・ユーザー数・無効ユーザー数・投稿数を表示する処理を実装  
  - 投稿一覧画面でAPIから投稿を取得し、ユーザー名・本文・投稿日をテーブル表示  
  - 設定変更画面を新規作成し、サポートメッセージを更新可能にした  
  - UI微調整（文字色、ホバー時の効果など）  
  - 各APIと連携し、実際のデータ取得／更新が可能な状態へ  

- **保留/やらないこと**  
  - 認証チェックの有効化（トークン未保持時のリダイレクト処理）はコメントアウト中 → 今後のセキュリティ対応で実装予定  
  - 管理者の登録画面は未着手 → 必要に応じて別ブランチで対応予定  

- **できるようになること（ユーザ目線）**  
  - 管理画面からユーザー一覧・投稿一覧・設定変更ページへスムーズに移動できる  
  - 投稿・ユーザー情報・サポートメッセージのリアルタイム管理が可能になる  

- **できなくなること（ユーザ目線）**  
  - 無し  

- **動作確認**  
  - ローカル環境で `localhost:3000/admin-home` 以下の各画面が正しく表示されることを確認  
  - ユーザー一覧、投稿一覧、設定変更の各ページでAPI通信成功を確認  
  - UI上の各リンク・ボタンが正しく機能することを確認済み  

- **その他**  
  - FastAPI 側のAPI実装と連携しているため、バックエンド側のエンドポイントの変更がある場合はフロントにも影響します  

- **close #**（該当Issueがあれば番号を入れてください）  

- **@**（レビュワーがいればメンション）
