### PR TITLE
ユーザー登録で user_name を API に送信するよう修正

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -22,12 +22,16 @@ export default function Register() {
     e.preventDefault();
 
     try {
-      const res = await fetch("http://localhost:8000/register", {
+      const res = await fetch("http://localhost:8000/api/register", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({
+          email,
+          password,
+          user_name: userName, // ← 修正：FastAPIと合わせる
+        }),
       });
 
       if (res.ok) {


### PR DESCRIPTION
- **目的**  
  FastAPI 側の `/register` エンドポイントと整合性を取るため、ユーザー登録時に `user_name` を送信できるようにする。

- **実装の概要/やったこと**  
  - フロントエンドの登録フォームで取得した `userName` を `user_name` として API リクエストボディに追加。  
  - `fetch` の `body` に `user_name: userName` を追加し、バックエンドが期待するスキーマと一致させた。  

- **保留/やらないこと**  
  - API のベース URL を `.env` 化する対応（今後デプロイ対応時に実施予定）  
  - バリデーションやエラーハンドリングの詳細な強化  

- **できるようになること（ユーザ目線）**  
  - お名前を入力して一般ユーザー登録ができるようになる  

- **できなくなること（ユーザ目線）**  
  - なし  

- **動作確認**  
  - `http://localhost:8000/api/register` に対して、`user_name`, `email`, `password` を送信  
  - FastAPI 側で新規ユーザーが登録され、トークンが返されることを確認  
  - 登録成功後 `/home` に遷移することを確認  

- **その他**  
  - フロントエンドとバックエンドのインターフェースが合っていなかったため、登録処理が失敗していた問題を解消しています。  

- **close #**（対応する Issue 番号があれば記載）  

- **@**（レビュー依頼するメンバーを記載）
