### PR TITLE
Feature/login token

### DIFF
--- a/src/app/admin-register/page.tsx
+++ b/src/app/admin-register/page.tsx
@@ -51,6 +51,12 @@ export default function AdminRegister(): JSX.Element {
       if (res.ok) {
         const data: RegisterResponse = await res.json();
         console.log("登録成功:", data);
+
+        // 🔑 トークン保存
+        if (data.token) {
+          localStorage.setItem("token", data.token);
+        }
+
         router.push("/admin-home");
       } else {
         const error: ErrorResponse = await res.json();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -34,6 +34,10 @@ export default function Login() {
       if (res.ok) {
         const data = await res.json();
         console.log("一般ユーザーログイン成功:", data);
+
+        // 🔑 トークン保存
+        localStorage.setItem("token", data.token);
+
         router.push("/home");
       } else {
         const error = await res.json();
@@ -62,6 +66,10 @@ export default function Login() {
       if (res.ok) {
         const data = await res.json();
         console.log("管理者ログイン成功:", data);
+
+        // 🔑 トークン保存
+        localStorage.setItem("token", data.token);
+
         router.push("/admin-home");
       } else {
         const error = await res.json();

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -37,6 +37,10 @@ const Register: React.FC = () => {
       if (res.ok) {
         const data = await res.json();
         console.log("登録成功:", data);
+
+        // 🔑 トークン保存
+        localStorage.setItem("token", data.token);
+
         router.push("/home");
       } else {
         const error = await res.json();

--- a/src/app/sabutyan-mode/page.tsx
+++ b/src/app/sabutyan-mode/page.tsx
@@ -7,9 +7,18 @@ import { useEffect, useState } from "react";
 
 export default function SabutyanMode() {
   const [message, setMessage] = useState("");
+  const [token, setToken] = useState("");
+  const [sessionId, setSessionId] = useState("");
 
   useEffect(() => {
     document.body.classList.add("washitsu");
+
+    const storedToken = localStorage.getItem("token");
+    const storedSessionId = localStorage.getItem("session_id");
+
+    if (storedToken) setToken(storedToken);
+    if (storedSessionId) setSessionId(storedSessionId);
+
     return () => {
       document.body.classList.remove("washitsu");
     };
@@ -34,6 +43,37 @@ export default function SabutyanMode() {
     }
   };
 
+  const handleMessageSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!token || !sessionId) {
+      alert("ログイン情報が不足しています");
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          content: message,
+        }),
+      });
+
+      if (!res.ok) throw new Error("メッセージ送信に失敗しました");
+
+      const result = await res.json();
+      alert("メッセージを送信しました！");
+      setMessage("");
+    } catch (error) {
+      console.error(error);
+      alert("メッセージ送信中にエラーが発生しました");
+    }
+  };
+
   return (
     <>
       <Logo />
@@ -52,7 +92,10 @@ export default function SabutyanMode() {
         </div>
 
         {/* メッセージ送信フォーム */}
-        <form className="fusuma-form text-lg md:text-xl">
+        <form
+          onSubmit={handleMessageSubmit}
+          className="fusuma-form text-lg md:text-xl"
+        >
           <label htmlFor="message">メッセージ</label>
           <textarea
             id="message"
@@ -69,7 +112,10 @@ export default function SabutyanMode() {
 
         {/* 元気をもらうボタン */}
         <div className="w-full max-w-md flex justify-end mt-2">
-          <button className="tatami-button text-lg px-6 py-3" onClick={handleEnergy}>
+          <button
+            className="tatami-button text-lg px-6 py-3"
+            onClick={handleEnergy}
+          >
             元気をもらう
           </button>
         </div>


### PR DESCRIPTION
## 目的  
ログイン／登録後にトークンを取得し、**ローカルストレージへ保存** することで、**認証付き API を利用可能** にする。  

## 実装の概要 / やったこと  
- 一般ユーザー・管理者ユーザーのログイン時に、トークンを `localStorage` へ保存する処理を追加  
- ユーザー登録・管理者登録時にも、トークンを `localStorage` へ保存する処理を追加  
- 各画面（ログイン・登録）での **リダイレクト先を統一**  

## 保留 / やらないこと  
- トークンの有効期限チェックや自動ログアウト処理（別途対応予定）  

## できるようになること（ユーザ目線）  
- ログイン・登録後に **自動で認証状態が維持** され、チャットや投稿などの機能が利用可能になる  

## できなくなること（ユーザ目線）  
- 無し  

## 動作確認  
- ローカル環境にて一般・管理者ユーザーの登録およびログインを実施  
- トークンが `localStorage` に保存されていることを **ブラウザの開発者ツールで確認**  
- トークン付きで **メッセージ投稿が可能** なことを確認  

## その他  
- トークンは `"token"` というキーで保存  
- バックエンドの `Authorization: Bearer` ヘッダーに対応していることが前提  

close #（対応する issue 番号があれば）  
